### PR TITLE
Correzione notifica mail soglia

### DIFF
--- a/administrator/config.xml
+++ b/administrator/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
     <fieldset label="COM_TGMAG" name="tgmag">
-        <field name="email" type="accesslevel" label="COM_TGMAG_FORM_LBL_EMAIL" description="COM_TGMAG_FORM_DESC_EMAIL" hint="COM_TGMAG_FORM_LBL_EMAIL"/>
+        <field name="email" type="usergroup" label="COM_TGMAG_FORM_LBL_EMAIL" description="COM_TGMAG_FORM_DESC_EMAIL" hint="COM_TGMAG_FORM_LBL_EMAIL"/>
 
     </fieldset>
 

--- a/administrator/tables/prodotto.php
+++ b/administrator/tables/prodotto.php
@@ -162,7 +162,7 @@ class TgmagTableprodotto extends JTable
 			$mailer->setSender($sender);
 						
 			// Get users in the group out of the ACL
-			$usersByGroup   = JAccess::getUsersByGroup(8);
+			$usersByGroup   = JAccess::getUsersByGroup($grp);
 			
 			$recipient = array();
 			foreach ($usersByGroup as $id)


### PR DESCRIPTION
la notifica della mail di soglia non arriva al gruppo configurato ma solo a amministratore
